### PR TITLE
ヘッダーフッター、ログアウト機能の実装 #12 #13

### DIFF
--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -2,10 +2,6 @@
   <div class="flex justify-center">
     <div class="w-full max-w-lg">
       <h1 class="text-2xl font-bold mb-6 text-gray-400">今日のいいところ</h1>
-      <div class='text-orange-400 hover:text-orange-600'>
-        <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>
-      </div>
-
 
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,11 +18,17 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
+  <body  class="flex flex-col min-h-screen">
+    <% if user_signed_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_login_header' %>
+    <% end %>
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container flex-grow mx-auto mt-10 px-5 flex">
       <%= yield %>
     </main>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <nav class="bg-orange-100">
     <div class="max-w-screen-xl flex flex-wrap items-center justify-between p-2">
-      <%= link_to "自分LOVE", '/' %>
+      <%= link_to "自分LOVE",(user_signed_in? ? root_path : root_path) %>
       <ul class = "flex">
         <li class="text-base mr-5">
           <%= link_to "新規登録", new_user_registration_path %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,15 @@
+<header>
+  <nav class="bg-orange-100">
+    <div class="max-w-screen-xl flex flex-wrap items-center justify-between p-2">
+      <%= link_to "自分LOVE", '/' %>
+      <ul class = "flex">
+        <li class="text-base mr-5">
+          <%= link_to "新規登録", new_user_registration_path %>
+        </li>
+        <li class="text-base mr-5">
+          <%= link_to "ログイン", new_user_session_path %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,18 @@
+<footer>
+  <nav class="bg-blue-100">
+    <div class="max-w-screen-xl flex flex-wrap justify-center items-center p-2">
+      <div class="w-full text-center">
+      <ul class = "flex text-gray-600  justify-center items-center text-xs gap-10">
+      <li>
+        <%= link_to "利用規約", '#' %>
+      </li>
+      <li>
+        <%= link_to "お問い合わせ", '#' %>
+      </li>
+      <li>
+        <%= link_to "プライバシーボリシー", '#' %>
+      </li>
+      </div>
+    </div>
+  </nav>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,14 @@
+<header>
+  <nav class="bg-orange-100">
+    <div class="max-w-screen-xl flex flex-wrap items-center justify-between p-2">
+    <%= link_to "自分LOVE", '/' %>
+      <ul class="flex">
+          
+        <li class="text-base mr-5">
+          <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>
+        </li>
+        
+      </ul>
+    </div>
+  </nav>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <nav class="bg-orange-100">
     <div class="max-w-screen-xl flex flex-wrap items-center justify-between p-2">
-    <%= link_to "自分LOVE", '/' %>
+    <%= link_to "自分LOVE", (user_signed_in? ? root_path : root_path) %>
       <ul class="flex">
           
         <li class="text-base mr-5">


### PR DESCRIPTION
## 概要
- [x] ログアウト機能の実装 close #12 
- [x] ヘッダーフッターの作成 close #13 

### 実装内容
- ログアウト機能
- ヘッダー（画面遷移実装済み）
    - ログイン前 => 「新規登録」「ログイン」
    - ログイン後 => 「ログアウト」
 - フッター（画面遷移未実装）
     - 「利用規約」「お問い合わせ」「プライバシーポリシー」
  
### できるようになったこと
- ログイン前
    - サイトロゴから、トップ画面へ遷移
    - 「新規登録」、「ログイン」ボタンから各画面へ遷移
- ログイン後
    - サイトロゴから、トップ画面へ遷移
    - 「ログアウト」ボタンから、ログアウト