### PR TITLE
翻訳の環境設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
+  config.i18n.default_locale = :ja
   config.i18n.fallbacks = true
 
   # Don't log any deprecations.


### PR DESCRIPTION
## 概要
i18nの翻訳環境設定

### 設定内容
production.rbにdefault_locale = :jaを明示的に記述
