### PR TITLE
会話履歴の実装

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,19 +1,19 @@
 class ConversationsController < ApplicationController
   def show_history
     posts = if user_signed_in?
-              current_user.posts.includes(:ai_response)
-            else
-              Post.includes(:ai_response).where(session_id: session.id)
-            end
-    # PostとAiResponseをcreated_atでソート        
+      current_user.posts.includes(:ai_response)
+    else
+      Post.includes(:ai_response).where(session_id: session.id)
+    end
+    # PostとAiResponseをcreated_atでソート
     combined_messages = posts.flat_map do |post|
-      [post, post.ai_response].compact
+      [ post, post.ai_response ].compact
     end.sort_by(&:created_at)
-    
+
     @messages = combined_messages.last(10)
 
     respond_to do |format|
-      format.html { render partial: 'messages/history', locals: { messages: @messages } }
+      format.html { render partial: "messages/history", locals: { messages: @messages } }
       format.turbo_stream do
         render turbo_stream: turbo_stream.update("conversation-history", partial: "messages/history", locals: { messages: @messages })
       end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,0 +1,22 @@
+class ConversationsController < ApplicationController
+  def show_history
+    posts = if user_signed_in?
+              current_user.posts.includes(:ai_response)
+            else
+              Post.includes(:ai_response).where(session_id: session.id)
+            end
+    # PostとAiResponseをcreated_atでソート        
+    combined_messages = posts.flat_map do |post|
+      [post, post.ai_response].compact
+    end.sort_by(&:created_at)
+    
+    @messages = combined_messages.last(10)
+
+    respond_to do |format|
+      format.html { render partial: 'messages/history', locals: { messages: @messages } }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update("conversation-history", partial: "messages/history", locals: { messages: @messages })
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/conversation_controller.js
+++ b/app/javascript/controllers/conversation_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="conversation"
+export default class extends Controller {
+  static targets = ["history"]
+
+  close() {
+    this.historyTarget.innerHTML = ""
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import ConversationController from "./conversation_controller"
+application.register("conversation", ConversationController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true
   validates :email, presence: true, uniqueness: true
 
   has_many :posts, dependent: :destroy

--- a/app/views/chats/_lead.html.erb
+++ b/app/views/chats/_lead.html.erb
@@ -1,6 +1,4 @@
-<div class="h-1/4">
 <p class="text-xs md:text-sm lg:text-base text-gray">
   今日はどんな良いことがありましたか？
   良かった出来事を書いて
   ポジティブ思考を育てましょう！</p>
-</div>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,7 +1,7 @@
 <!-- ページネーション後、背景画像を全画面共有にする -->
-<div class="flex flex-col md:flex-row h-[calc(100vh-HEADER_FOOTER_HEIGHT_px)] bg-hero-pattern bg-cover bg-top">
+<div class="flex flex-col md:flex-row min-h-screen bg-hero-pattern bg-cover bg-top">
   <!-- menu -->
-  <div class="order-3 md:order-1 w-full md:w-1/5 p-4 fixed bottom-0 left-0 z-10 bg-white md:static md:h-auto">
+  <div class="order-3 md:order-1 w-full md:w-1/5 p-4 fixed bottom-0 left-0 z-10 bg-white md:static md:h-full">
       <%= render 'menu' %>
   </div>
 
@@ -48,10 +48,11 @@
               <%= button_to '新しく書く', chat_reset_path, method: :delete %>
             </div>
             <!-- 会話履歴 -->
-            <%= link_to "会話履歴を表示", conversation_history_path,
-                        data: { turbo_stream: true, turbo_target: "conversation-history" },
-                        class: "btn btn-secondary" %>           
-           
+            <div class="mx-10 my-2 text-gray-600 hover:text-amber-400">
+              <%= link_to "会話履歴を表示", conversation_history_path,
+                          data: { turbo_stream: true, turbo_target: "conversation-history" },
+                          class: "btn btn-secondary" %>           
+            </div>
           </div>
         </div>
       </div>
@@ -59,22 +60,22 @@
   </div>
 
   <div class="order-1 md:order-3 w-full md:w-1/5 p-4">
-  <div class="h-full flex flex-col justify-between p-4 space-y-4">
-    <!-- 上部：リード文（1/4）-->
-    <div class="h-1/4">
-      <% if user_signed_in? %>
-        <%= render 'lead' %>
-      <% else %>
-        <%= render 'before_login_lead' %>
-      <% end %>
-    </div>
+    <div class="h-full flex flex-col justify-between p-4 space-y-4">
+      <!-- 上部：リード文（1/4）-->
+      <div class="h-1/4">
+        <% if user_signed_in? %>
+          <%= render 'lead' %>
+        <% else %>
+          <%= render 'before_login_lead' %>
+        <% end %>
+      </div>
 
-    <!-- 下部：会話履歴（3/4）-->
-    <div class="h-3/4 overflow-y-auto">
-      <div id="conversation-history"></div>
+      <!-- 下部：会話履歴（3/4）-->
+      <div class="h-3/4 overflow-y-auto">
+        <div id="conversation-history"></div>
+      </div>
     </div>
   </div>
-</div>
   </div>
   
 </div>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -47,20 +47,34 @@
             <div class="mx-10 my-2 text-gray-600 hover:text-amber-400">
               <%= button_to '新しく書く', chat_reset_path, method: :delete %>
             </div>
+            <!-- 会話履歴 -->
+            <%= link_to "会話履歴を表示", conversation_history_path,
+                        data: { turbo_stream: true, turbo_target: "conversation-history" },
+                        class: "btn btn-secondary" %>           
+           
           </div>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- リード文 -->
-  <div class="order-1 md:order-3 w-full md:w-1/5  p-4">
-    <div class="h-full flex items-start justify-end p-4">
+  <div class="order-1 md:order-3 w-full md:w-1/5 p-4">
+  <div class="h-full flex flex-col justify-between p-4 space-y-4">
+    <!-- 上部：リード文（1/4）-->
+    <div class="h-1/4">
       <% if user_signed_in? %>
         <%= render 'lead' %>
       <% else %>
         <%= render 'before_login_lead' %>
       <% end %>
     </div>
+
+    <!-- 下部：会話履歴（3/4）-->
+    <div class="h-3/4 overflow-y-auto">
+      <div id="conversation-history"></div>
+    </div>
   </div>
+</div>
+  </div>
+  
 </div>

--- a/app/views/messages/_history.html.erb
+++ b/app/views/messages/_history.html.erb
@@ -1,5 +1,11 @@
-<div id="conversation-history">
-  <div class="w-full max-w-md border border-gray-400 rounded-md">
+<div id="conversation-history" data-controller="conversation" data-conversation-target="history">
+  <div class="w-full max-w-md border border-gray-400 rounded-md relative"> 
+    <!-- 閉じるボタン -->
+    <div class="flex justify-end">
+      <button type="button" data-action="conversation#close" class="absolute top-2 right-2 p-2 text-gray-500 hover:text-gray-800">
+      ✕
+      </button>
+    </div>
     <% if @messages.any? %>
       <% @messages.each do |message| %>
         <% if message.is_a?(Post) %>

--- a/app/views/messages/_history.html.erb
+++ b/app/views/messages/_history.html.erb
@@ -1,0 +1,25 @@
+<div id="conversation-history">
+  <div class="w-full max-w-md border border-gray-400 rounded-md">
+    <% if @messages.any? %>
+      <% @messages.each do |message| %>
+        <% if message.is_a?(Post) %>
+          <div class="flex justify-end">
+            <div class="message-item">
+              <p><%= message.content %></p>
+              <small class="text-xs text-gray-500"><%= l message.created_at, format: :short %></small>
+            </div>
+          </div>
+        <% elsif message.is_a?(AiResponse) %>
+          <div class="flex justify-start">
+            <div class="message-item">
+              <p><%= message.content %></p>
+              <small class="text-xs text-gray-500"><%= l message.created_at, format: :short %></small>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p>まだ会話履歴はありません。</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/messages/_history.html.erb
+++ b/app/views/messages/_history.html.erb
@@ -22,7 +22,7 @@
               <small class="text-xs text-gray-500"><%= l message.created_at, format: :short %></small>
             </div>
           </div>
-        <% end %>
+        <% end %> 
       <% end %>
     <% else %>
       <p>まだ会話履歴はありません。</p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,6 @@ ja:
       signed_in: "ログインしました"
       new:
         title: "ログイン"
+  time:
+    formats:
+      short: "%Y/%m/%d %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "chats#index"
+  delete "/chat_reset", to: "posts#reset_chat"
+  get "conversation_history", to: "conversations#show_history"
 
   resources :chats, only: [ :index, :create ]
   resources :posts, only: [ :index ]
-  delete "/chat_reset", to: "posts#reset_chat"
 end


### PR DESCRIPTION
## 概要
会話履歴の実装
トップ画面に非同期表示

## 実装内容

- コントローラーの作成
app/controllers/conversations_controller.rb作成
#show_history　会話履歴を取得するロジックを作成
ユーザーの投稿(Post)とAIの返答(AiResponse)を作成日時準にソートして表示（最大１０件表示）

　　会話履歴の表示はTurboStreamを使用

- ルーティング
get "conversation_history"

- ビュー
views/chats/index.html.erbに会話ボタンを作成
Turbo Streamリクエストを送信

　　views/messages/_history.html.erb 作成、編集
　　会話履歴の表示コンポーネント作成

- JavaScript
app/javascript/controllers/conversation_history_controller.js 作成
会話履歴を閉じる機能をJSで実装

## できるようになったこと
-  ログイン時
    - 「会話履歴を表示」ボタンをクリックすると、会話履歴画面が表示される
    - 会話履歴が長い場合はスクロールができる
    - 会話履歴画面の「×」をクリックすると会話履歴画面が閉じる
    
## できないこと(未実装)
- ゲストユーザー
    - 「会話履歴を表示」をクリックするとログイン画面へ遷移する
    