### PR TITLE
ゲストの会話履歴表示

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,5 +1,5 @@
 class ConversationsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show_history]
+  skip_before_action :authenticate_user!, only: [ :show_history ]
   def show_history
     posts = if user_signed_in?
       current_user.posts.includes(:ai_response)


### PR DESCRIPTION
## 概要
ゲストの会話履歴表示

## 実装内容
- 認証の解除
conversations_controller.rb
`skip_before_action :authenticate_user!, only: [:show_history]`を記述

## できるようになったこと
- ゲスト機能時
    - 「会話履歴を表示」をクリックすると会話履歴画面が表示される
    - 会話履歴画面の「×」をクリックすると会話履歴画面が閉じる
