### PR TITLE
ローディングの実装

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -6,12 +6,12 @@ class ChatsController < ApplicationController
 
   def create
     if user_signed_in?
-      post = current_user.posts.create!(content: params[:content])
+      @post = current_user.posts.create!(content: params[:content])
     else
-      post = Post.create!(content: params[:content], session_id: session.id)
+      @post = Post.create!(content: params[:content], session_id: session.id)
     end
 
-    GenerateAiResponseJob.perform_later(post.id)
+    GenerateAiResponseJob.perform_later(@post.id)
 
     respond_to do |format|
       format.turbo_stream

--- a/app/jobs/generate_ai_response_job.rb
+++ b/app/jobs/generate_ai_response_job.rb
@@ -9,7 +9,7 @@ class GenerateAiResponseJob < ApplicationJob
 
     post.create_ai_response!(content: ai_reply)
     post.reload
-    
+
     stream_id =
       if post.user.present? # postにユーザーIDがある場合
         "chat_user_#{post.user_id}"

--- a/app/jobs/generate_ai_response_job.rb
+++ b/app/jobs/generate_ai_response_job.rb
@@ -8,7 +8,8 @@ class GenerateAiResponseJob < ApplicationJob
     ai_reply = OpenaiClient.new.generate_response(user_text)
 
     post.create_ai_response!(content: ai_reply)
-
+    post.reload
+    
     stream_id =
       if post.user.present? # postにユーザーIDがある場合
         "chat_user_#{post.user_id}"
@@ -17,11 +18,11 @@ class GenerateAiResponseJob < ApplicationJob
       end
 
     # Turbo Streamで返答を表示（broadcasting）
-    Turbo::StreamsChannel.broadcast_append_to(
+    Turbo::StreamsChannel.broadcast_replace_to(
       stream_id,
-      target: "chat_messages",
+      target: "loading-#{post.id}",
       partial: "chats/message",
-      locals: { message: { user: post.content, ai: ai_reply } }
+      locals: { message: post }
     )
   end
 end

--- a/app/views/chats/_message.html.erb
+++ b/app/views/chats/_message.html.erb
@@ -1,7 +1,11 @@
-<div class="chat-item">
+<div id="loading-<%= message.id %>" class="chat-item">
   <div class="flex justify-center">
-    <div class=" tracking-wide text-left">
-      <p><%= message[:ai] %></p>
+    <div class="tracking-wide text-left">
+      <% if message.ai_response.present? %>
+        <p><%= message.ai_response.content %></p>
+      <% else %>
+        <p class="text-gray-500 animate-pulse">🤖 AIが考え中です…</p>
+      <% end %>
+    </div>
   </div>
-  </div>  
 </div>

--- a/app/views/chats/_message.html.erb
+++ b/app/views/chats/_message.html.erb
@@ -4,7 +4,7 @@
       <% if message.ai_response.present? %>
         <p><%= message.ai_response.content %></p>
       <% else %>
-        <p class="text-gray-500 animate-pulse">🤖 AIが考え中です…</p>
+        <p class="animate-bounce font-bold text-pink-400">Good Job!</p>
       <% end %>
     </div>
   </div>

--- a/app/views/chats/create.turbo_stream.erb
+++ b/app/views/chats/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+
+<%= turbo_stream.append "chat_messages" do %>
+    <%= render partial: "chats/message", locals: { message: @post } %>
+  <% end %>

--- a/app/views/chats/create.turbo_stream.erb
+++ b/app/views/chats/create.turbo_stream.erb
@@ -1,4 +1,4 @@
 
 <%= turbo_stream.append "chat_messages" do %>
-    <%= render partial: "chats/message", locals: { message: @post } %>
-  <% end %>
+  <%= render partial: "chats/message", locals: { message: @post } %>
+<% end %>


### PR DESCRIPTION
## 概要
AI返答時のローディングの実装

## 実装内容
- app/views/chats/create.turbo_stream.erb作成
投稿後にローディングを表示（_message.html.erbをレンダリング）
- app/jobs/generate_ai_response_job.rb修正
broadcast_replace_toのtarget:変更
- app/views/chats/_message.html.erb修正
 Aiの返答がない時はローディングを表示させる分岐を追加
