### PR TITLE
レスポンシブ対応

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @posts = current_user.posts.order(created_at: :desc).page(params[:page]).per(1)
+    @posts = current_user.posts.order(created_at: :desc).page(params[:page])
     # 合計件数
     @total_posts_count = @posts.count
     # 連続記録日数

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @posts = current_user.posts.order(created_at: :desc).page(params[:page])
+    @posts = current_user.posts.order(created_at: :desc).page(params[:page]).per(1)
     # 合計件数
     @total_posts_count = @posts.count
     # 連続記録日数

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,11 +1,11 @@
 <!-- ページネーション後、背景画像を全画面共有にする -->
 <div class="grid grid-cols-1 md:grid-cols-12 grid-rows-10 h-screen bg-hero-pattern bg-cover bg-top">
   <!-- menu 画面左-->
-  <div class="col-span-12 md:col-span-2 row-span-10 p-4 fixed bottom-0 bg-white md:static md:h-full">
+  <div class="col-span-1 md:col-span-2 row-span-10 p-4 fixed bottom-0 bg-white md:static md:h-full">
       <%= render 'menu' %>
   </div>
   <!-- chat 画面中央-->
-  <div class="col-span-12 row-span-7 row-start-2 md:col-span-4 md:col-start-5 md:row-span-10 p-4 overflow-hidden">
+  <div class="col-span-1 row-span-7 row-start-2 md:col-span-4 md:col-start-5 md:row-span-10 p-4 overflow-hidden">
     <div class="w-full text-center ">
       <h1 class="sm:text-sm md:text-xl lg:text-2xl mt-4 mb-6 text-gray-600">今日のいいところ</h1>
       <!-- ユーザー入力フォーム -->
@@ -54,7 +54,7 @@
       </div>
     </div>
     <!-- 画面右 -->   
-    <div class="col-span-12 md:col-span-2 md:col-end-13 row-span-1 row-start-1 p-4 ">
+    <div class="col-span-1 md:col-span-2 md:col-end-13 row-span-1 row-start-1 p-4 ">
       <!-- 上部：リード文-->
       <% if user_signed_in? %>
         <%= render 'lead' %>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,7 +1,7 @@
 <!-- ページネーション後、背景画像を全画面共有にする -->
 <div class="grid grid-cols-1 md:grid-cols-12 grid-rows-10 h-screen bg-hero-pattern bg-cover bg-top">
   <!-- menu 画面左-->
-  <div class="col-span-1 md:col-span-2 row-span-10 p-4 fixed bottom-0 bg-white md:static md:h-full">
+  <div class="col-span-1 md:col-span-2 row-span-10 w-full p-4 fixed bottom-0 bg-white md:static md:h-full">
       <%= render 'menu' %>
   </div>
   <!-- chat 画面中央-->

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,2 +1,2 @@
 <!-- 「最初のページ」へのリンク -->
-<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light px-2 border border-gray-400 rounded shadow" %>
+<%= link_to_unless current_page.first?, t('pagination.first').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light px-2 border border-gray-400 rounded shadow" %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,2 +1,2 @@
 <!-- 「…」などの省略記号 -->
-<span class="tracking-widest text-gray-600 px-2"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="tracking-widest text-gray-600 px-2"><%= t('pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,2 +1,2 @@
 <!-- 「最後のページ」へのリンク -->
-<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light px-2 border border-gray-400 rounded shadow" %>
+<%= link_to_unless current_page.last?, t('pagination.last').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light px-2 border border-gray-400 rounded shadow" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,2 +1,2 @@
 <!-- 「次のページ」へのリンク -->
-<%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "bg-cyan-200 hover:bg-cyan-400 text-gray-600 font-light px-2 rounded shadow" %>
+<%= link_to_unless current_page.last?, t('pagination.next').html_safe, url, rel: 'next', remote: remote, class: "bg-cyan-200 hover:bg-cyan-400 text-gray-600 font-light px-2 rounded shadow" %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,2 +1,2 @@
 <!-- 「前のページ」へのリンク -->
-<%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "bg-cyan-200 hover:bg-cyan-400 text-gray-600 font-light px-2 rounded shadow" %>
+<%= link_to_unless current_page.first?, t('pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "bg-cyan-200 hover:bg-cyan-400 text-gray-600 font-light px-2 rounded shadow" %>

--- a/app/views/posts/_button.html.erb
+++ b/app/views/posts/_button.html.erb
@@ -1,10 +1,14 @@
-<div class="mt-4 mb-6 text-gray-700 space-y-2">
-  <p class="text-sm md:text-base lg:text-lg flex">
-    <%= inline_svg("return", class: "w-5 h-5 text-gray-800 mx-1 my-1") %>
-    <%= link_to back_text, back_path, class: "hover:text-amber-500 hidden md:block" %>
-  </p>
-  <p class="text-sm md:text-base lg:text-lg flex">
-    <%= inline_svg("pencil", class: "w-5 h-5 text-gray-800 mx-1 my-1") %>
-    <%= link_to "ポジティブを書く", root_path, class: "hover:text-cyan-500 hidden md:block" %>
-  </p>
+<div class="flex justify-center md:flex-col md:text-left mt-4">
+  <div class="text-gray-700 mx-2">
+    <%= link_to back_path, class: "flex text-sm lg:text-base group" do %>
+      <%= inline_svg("return", class: "w-5 h-5 text-gray-800 mx-1 md:my-1 group-hover:text-amber-500") %>
+      <span class="group-hover:text-amber-500"><%= back_text %></span> 
+    <% end %>
+  </div>
+  <div class="text-gray-700 mx-2">
+    <%= link_to root_path, class: "flex text-sm lg:text-base group" do %>
+      <%= inline_svg("pencil", class: "w-5 h-5 text-gray-800 mx-1 md:my-1 group-hover:text-cyan-500") %>
+      <span class="group-hover:text-cyan-500"><%= "ポジティブを書く" %></span>
+    <% end %>
+  </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <% posts.group_by { |post| post.created_at.to_date }.each do |date, posts| %>
   <div class="col-span-full mb-4">
-    <h2 class="text-lg text-gray-700 border-b pb-2 mb-2"><%= date.strftime("%Y年%m月%d日") %></h2>
+    <h2 class="text-lg text-gray-700 border-b-2 pb-2 mb-2"><%= date.strftime("%Y年%m月%d日") %></h2>
     <div class="grid gap-3 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
       <% posts.each do |post| %>
         <div class="flex flex-col rounded-lg border-4 border-amber-400 p-4 hover:shadow-lg transition-shadow duration-300">

--- a/app/views/posts/_total.html.erb
+++ b/app/views/posts/_total.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-4 mb-6 text-gray-700 space-y-2 text-center md:text-right">
-  <p class="text-sm md:text-base lg:text-lg border-b border-gray-400 inline-block">累計ポジティブ数：<%= @total_posts_count %></p>
-  <p class="text-sm md:text-base lg:text-lg border-b border-gray-400 inline-block">連続記録日数：<%= @consecutive_days %> 日</p>
+<div class="mt-4 text-gray-700 space-y-2 text-center md:text-right">
+  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">累計ポジティブ数：<%= @total_posts_count %></p>
+  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">連続記録日数：<%= @consecutive_days %> 日</p>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,15 +1,17 @@
 <div class="mx-10 my-4">
   <!-- ページトップ -->
-  <div class="flex flex-col md:flex-row">
-    <div class="md:order-1 md:w-1/4"> 
+  <div class="grid grid-cols-1 md:grid-cols-5 grid-rows-1 md:grid-rows-2 w-full justify-center mb-5">
+  <div class="row-start-3 md:col-span-1 md:row-start-1">
       <%= render "button", back_text: "カレンダーに戻る", back_path: "#" %>
     </div>
-    <div class="order-1 md:order-2 md:w-2/4">
+    <div class="row-span-1  md:col-span-3 md:row-start-1">
       <h1 class="text-2xl md:text-3xl lg:text-4xl mt-4 text-gray-600 text-center">あなたのポジティブ一覧</h1>
+    </div>  
       <!-- 上部ページネーション -->
+      <div class="row-start-4  md:col-span-3 md:row-start-2 md:col-start-2  mt-3">
       <%= paginate @posts %>  
-    </div>
-    <div class="order-2 md:order-3 md:w-1/4">
+      </div>
+    <div class="row-start-2 md:col-span-1 md:row-start-1">
       <%= render "total" %>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,17 +1,16 @@
 <div class="mx-10 my-4">
   <!-- ページトップ -->
   <div class="flex flex-col md:flex-row">
-    <div class="md:order-1 md:w-1/4"> 
+    <div class="order-2 md:order-1 md:w-1/4 mb-4"> 
       <%= render "button", back_text: "一覧に戻る", back_path: posts_path %>
     </div>
     <div class="order-1 md:order-2 md:w-2/4">
-      <h1 class="text-2xl md:text-3xl lg:text-4xl mt-4 text-gray-600 text-center">ポジティブ詳細</h1>
+      <h1 class="text-2xl md:text-3xl lg:text-4xl m-4 text-gray-600 text-center">ポジティブ詳細</h1>
     </div>
   </div>
   <!-- 投稿詳細 -->
   <div class="flex justify-center mt-8">
-    <h2 class="w-full max-w-md text-lg text-gray-700 border-b border-gray-500 mb-2"><%= l(@post.created_at, format: :short) %></h2>
-  
+    <h2 class="w-full max-w-md text-lg text-gray-700 border-b border-gray-500 mb-2"><%= l(@post.created_at, format: :short) %></h2> 
     <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
       <div class="inline-block border-b border-gray-500">
         <%= inline_svg("trash", class: "w-5 h-5 text-gray-800 hover:text-amber-500 mx-1 my-1") %>


### PR DESCRIPTION
## 概要
レスポンシブ対応時の修正
- [x] 一覧画面上部
- [x] トップ画面メニュー
- [x] kaminariのi18n修正 

## 実装内容
- [x] 一覧画面上部
- flexからgridに変更
- 「戻るボタン」
　ホバー時のテキストとSVGをグループ化
- スマホ時の表示位置変更
　上から、タイトル→トータル→ボタン
- その他
　文字サイズ、間隔の調整
- [x] トップ画面メニュー
- 画面サイズに応じたメニュー幅の自動調整

