### PR TITLE
プロフィール画像の登録、変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,21 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -179,6 +190,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.3.0)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -316,6 +329,9 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.4)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.32.0)
@@ -397,6 +413,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dockerfile-rails (>= 1.7)
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -49,7 +49,23 @@ class ProfilesController < ApplicationController
   end
 
   def update_avatar
+    @user = current_user
+
+    if @user.update(profile_params)
+      flash.now[:notice] = "プロフィール画像を更新しました。"
+
+      respond_to do |format|
+        format.html { redirect_to profile_path }
+        format.turbo_stream
+      end
+    else
+      respond_to do |format|
+        format.html { render :edit_avatar, status: :unprocessable_entity }
+        format.turbo_stream { render :edit_avatar, status: :unprocessable_entity }
+      end
+    end
   end
+
 
   private
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -38,6 +38,14 @@ class ProfilesController < ApplicationController
 
   # アバター編集
   def edit_avatar
+    @user = current_user
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update("avatar-edit-form", partial: "profiles/edit_avatar", locals: { user: @user }
+      )
+      end
+    end
   end
 
   def update_avatar

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :ai_responses, through: :posts
   belongs_to :character, optional: true
+  has_one_attached :avatar
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/chats/_menu.html.erb
+++ b/app/views/chats/_menu.html.erb
@@ -49,7 +49,7 @@
     label: "プロフィール設定（準備中）",
     bg: "bg-cyan-200",
     icon: "setting",
-    logged_in_path: "#",
+    logged_in_path: profile_path,
     logged_in_options: {},
     guest_path: profile_setting_path,
     guest_options: {

--- a/app/views/profiles/_avatar_display.html.erb
+++ b/app/views/profiles/_avatar_display.html.erb
@@ -1,0 +1,7 @@
+<div class="box-border border-2 rounded-full w-24 h-24 md:w-32 md:h-32 flex items-center justify-center mb-4 overflow-hidden">
+  <% if @user.avatar.attached? %>
+    <%= image_tag @user.avatar, class: "w-full h-full object-cover" %>
+  <% else %>
+    未設定
+  <% end %>
+</div>

--- a/app/views/profiles/_avatar_display.html.erb
+++ b/app/views/profiles/_avatar_display.html.erb
@@ -1,6 +1,9 @@
-<div class="box-border border-2 rounded-full w-24 h-24 md:w-32 md:h-32 flex items-center justify-center mb-4 overflow-hidden">
+<div class="box-border border rounded-full w-24 h-24 md:w-32 md:h-32 flex items-center justify-center mb-4 overflow-hidden">
   <% if @user.avatar.attached? %>
-    <%= image_tag @user.avatar, class: "w-full h-full object-cover" %>
+   <%= image_tag(
+        "#{url_for(user.avatar)}?v=#{user.updated_at.to_i}",
+        class: "w-full h-full object-cover object-center"
+      ) %>
   <% else %>
     未設定
   <% end %>

--- a/app/views/profiles/_avatar_filename.html.erb
+++ b/app/views/profiles/_avatar_filename.html.erb
@@ -1,0 +1,3 @@
+<% if @user.avatar.attached? %>
+  <p>ファイル名: <%= @user.avatar.blob.filename %></p>
+<% end %>

--- a/app/views/profiles/_edit_avatar.html.erb
+++ b/app/views/profiles/_edit_avatar.html.erb
@@ -1,0 +1,18 @@
+<div class="avatar-edit-form" data-controller="closable" data-closable-target="content">
+  <div class="w-64 border-2 bg-amber-100 my-10 px-4 py-2 rounded-md">
+    <div class="flex justify-end">
+      <button type="button" data-action="closable#close" class=" text-gray-500 hover:text-gray-800">
+      ✕
+      </button>
+    </div>
+    <%= form_with model: @user, url:  update_avatar_profile_path, method: :patch do |f| %>
+      <div>
+        <%= f.label :avatar, class: "text-sm" %>
+        <%= f.file_field :avatar, class: "text-sm" %>
+      </div>
+      <div class="text-center hover:text-amber-600 mt-4">
+        <%= f.submit "更新" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/_edit_avatar.html.erb
+++ b/app/views/profiles/_edit_avatar.html.erb
@@ -1,5 +1,5 @@
 <div class="avatar-edit-form" data-controller="closable" data-closable-target="content">
-  <div class="w-64 border-2 bg-amber-100 my-10 px-4 py-2 rounded-md">
+  <div class="w-80 border-2 bg-amber-100 my-10 px-4 py-2 rounded-md">
     <div class="flex justify-end">
       <button type="button" data-action="closable#close" class=" text-gray-500 hover:text-gray-800">
       ✕
@@ -8,7 +8,7 @@
     <%= form_with model: @user, url:  update_avatar_profile_path, method: :patch do |f| %>
       <div>
         <%= f.label :avatar, class: "text-sm" %>
-        <%= f.file_field :avatar, class: "text-sm" %>
+        <%= f.file_field :avatar, class: "text-xs" %>
       </div>
       <div class="text-center hover:text-amber-600 mt-4">
         <%= f.submit "更新" %>

--- a/app/views/profiles/_edit_name.html.erb
+++ b/app/views/profiles/_edit_name.html.erb
@@ -1,5 +1,4 @@
-
-<div class="how-to-write" data-controller="closable" data-closable-target="content">
+<div class="name-edit-form" data-controller="closable" data-closable-target="content">
   <div class="w-64 border-2 bg-amber-100 my-10 px-4 py-2 rounded-md">
     <div class="flex justify-end">
       <button type="button" data-action="closable#close" class=" text-gray-500 hover:text-gray-800">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,8 +5,10 @@
       
       <!-- 画面左：アバター表示 -->
       <div class="md:col-span-1 md:flex md:flex-col text-center items-center md:mt-10">
-        <div id="avatar_area">  
-          <%= render 'profiles/avatar_display', user: @user %>
+        <div id="avatar_area">
+        <div class="">
+          <%= render "profiles/avatar_display", user: @user %>
+        </div>
         </div>
         <div id="main-username">
           <%= render "shared/username", user: @user %>
@@ -56,7 +58,9 @@
               data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
               class: "bg-amber-200 text-sm px-1" %>
             </div>
-            <span></span>
+            <% if @user.avatar.attached? %>
+              <p>ファイル名: <%= @user.avatar.blob.filename %></p>
+            <% end %>
           </div>
         </div>
         <turbo-frame id="profile_name_edit"></turbo-frame>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -50,7 +50,9 @@
           <div class="my-4 p-2">
             <div class="flex items-center justify-between mb-2">
               <p>プロフィール画像</p>
-              <%= link_to "編集", "#", class: "bg-amber-200 text-sm px-1" %>
+              <%= link_to "編集", edit_avatar_profile_path,
+              data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
+              class: "bg-amber-200 text-sm px-1" %>
             </div>
             <span></span>
           </div>
@@ -59,6 +61,7 @@
       </div>
       <div class="col-span-1 row-span-1 row-start-1 md:col-span-2 md:col-start-4 m-4 flex justify-center">
         <div id="name-edit-form"></div>
+        <div id="avatar-edit-form"></div>
       </div>
     </div>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,10 +5,8 @@
       
       <!-- 画面左：アバター表示 -->
       <div class="md:col-span-1 md:flex md:flex-col text-center items-center md:mt-10">
-        <div id="avatar_area">
-        <div class="">
+        <div id="avatar-area">
           <%= render "profiles/avatar_display", user: @user %>
-        </div>
         </div>
         <div id="main-username">
           <%= render "shared/username", user: @user %>
@@ -55,15 +53,14 @@
             <div class="flex items-center justify-between mb-2">
               <p>プロフィール画像</p>
               <%= link_to "編集", edit_avatar_profile_path,
-              data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
-              class: "bg-amber-200 text-sm px-1" %>
+                          data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
+                          class: "bg-amber-200 text-sm px-1" %>
             </div>
-            <% if @user.avatar.attached? %>
-              <p>ファイル名: <%= @user.avatar.blob.filename %></p>
-            <% end %>
+            <div id="avatar-filename">
+              <%= render "profiles/avatar_filename", user: @user %>
+            </div>
           </div>
         </div>
-        <turbo-frame id="profile_name_edit"></turbo-frame>
       </div>
       <div class="col-span-1 row-span-1 row-start-1 md:col-span-2 md:col-start-4 m-4 flex justify-center">
         <div id="name-edit-form"></div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,8 +4,10 @@
     <div class="grid grid-cols-1 grid-row-5 md:grid-cols-5 w-full justify-center p-4">
       
       <!-- 画面左：アバター表示 -->
-      <div class="md:col-span-1 flex flex-col text-center">
-        <!-- アバター表示 -->
+      <div class="md:col-span-1 md:flex md:flex-col text-center items-center md:mt-10">
+        <div id="avatar_area">  
+          <%= render 'profiles/avatar_display', user: @user %>
+        </div>
         <div id="main-username">
           <%= render "shared/username", user: @user %>
         </div>

--- a/app/views/profiles/update_avatar.turbo_stream.erb
+++ b/app/views/profiles/update_avatar.turbo_stream.erb
@@ -1,4 +1,8 @@
-<%= turbo_stream.replace "avatar_area", partial: "devise/character_display", locals: { user: @user } %>   
+<!-- プロフィール画像の置き換え -->
+<%= turbo_stream.replace "avatar-area", partial: "profiles/avatar_display", locals: { user: @user } %>   
+
+<!-- ファイル名の置き換え -->
+<%= turbo_stream.replace "avatar-filename", partial: "profiles/avatar_filename", locals: { user: @user } %> 
 
 <%= turbo_stream.update "avatar-edit-form" do %>
   <!-- 空にして閉じる -->

--- a/app/views/profiles/update_avatar.turbo_stream.erb
+++ b/app/views/profiles/update_avatar.turbo_stream.erb
@@ -1,7 +1,5 @@
-<%= turbo_stream.update "avatar_area" do %>
-  <%= render "devise/character_display", user: current_user %>
-<% end %>
-    
+<%= turbo_stream.replace "avatar_area", partial: "devise/character_display", locals: { user: @user } %>   
+
 <%= turbo_stream.update "avatar-edit-form" do %>
   <!-- 空にして閉じる -->
 <% end %>

--- a/app/views/profiles/update_avatar.turbo_stream.erb
+++ b/app/views/profiles/update_avatar.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.update "avatar_area" do %>
+  <%= render "devise/character_display", user: current_user %>
+<% end %>
+    
+<%= turbo_stream.update "avatar-edit-form" do %>
+  <!-- 空にして閉じる -->
+<% end %>
+  
+<%= turbo_stream.update "flash" do %>
+  <%= render "layouts/flash" %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,11 +2,11 @@
   <nav class="bg-amber-200">
     <div class=" flex flex-wrap justify-between p-2">
     <%= link_to "自分LOVE", (user_signed_in? ? root_path : root_path), class: "text-sm md:text-base text-gray-700" %>
-      <ul class="flex">   
+      <ul class="flex">
         <li class="text-sm md:text-base mr-5 text-gray-700">
-        <div id="username">
-          <%= render "shared/username", user: current_user %>
-        </div>
+          <div id="username">
+            <%= render "shared/username", user: current_user %>
+          </div>
         </li>
         <li class="text-sm md:text-base mr-3 text-gray-700">
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,6 @@ module Myapp
 
     config.i18n.default_locale = :ja # デフォルトの言語
     config.time_zone = "Tokyo" # タイムゾーン
+    config.active_storage.variant_processor = :mini_magick # ActiveStorage
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -7,6 +7,7 @@ ja:
       user:
         email: メールアドレス
         name: 名前
+        avatar: プロフィール画像
         password: パスワード
         password_confirmation: パスワード確認      
   attributes:

--- a/db/migrate/20250813220354_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250813220354_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20250813235024_rename_avater_column_to_users.rb
+++ b/db/migrate/20250813235024_rename_avater_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameAvaterColumnToUsers < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :users, :avater, :avatar
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_13_220354) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_13_235024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_13_220354) do
     t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "avater"
+    t.string "avatar"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_26_204943) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_13_220354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "ai_responses", force: :cascade do |t|
     t.text "content", null: false
@@ -54,6 +82,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_204943) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "ai_responses", "posts"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## 概要
プロフィール画像の登録、変更の実装
- [x] Active Strageの導入
- [x]  プロフィール画像の登録、変更の実装

## 導入したGem
gem "image_processing", "~> 1.2"

## 実装内容
- [x] Active Strageの導入
- Active Strageインストール
- gem "image_processing"インストール
- `config/storage.yml`の設定
本番環境での設定は後日

- [x]  プロフィール画像の登録、変更の実装

**コントローラー**
- `edit_avatar`,`update_avatar`アクション編集
TurboStream記述
    - edit_avatarアクションで/profiles/_edit_avatar.html.erbを非同期表示
    - update_avatarアクションで/profiles/update_avatar.turbo_stream.erb内の処理実行
   
**ルーティング**
edit => get
update => patch

**ビュー**
- `/profiles/_edit_avatar.html.erb`作成、編集
置き換えのid => avatar-edit-form

- `/profiles/update_avatar.turbo_stream.erb`作成、編集
    - 画像表示用、ファイル名表示用のパーシャル作成
（profiles/_avatar_display.html.erb, profiles/_avatar_filename.html.erb）
    - キャッシュの削除（ profiles/_avatar_display.html.erb）
   image_tag に `?v=#{@user.updated_at.to_i}`をつけて、更新されるたびにURLが変わるようにする。

## できるようになったこと
プロフィール設定画面の左側にプロフィール画像が表示される。
- プロフィール画像未設定の場合は、「未設定」の表示が出る。
- プロフィール画像の「編集」をクリックすると非同期で画像登録フォームが表示される。
- 画像を選択し、「更新」をクリックすると、画面左に画像が表示される。また、基本情報欄のプロフィール画像の枠にファイル名が表示される。
- 画像を更新すると、「プロフィール画像が更新されました」とフラッシュメーセージが表示される。

## 未実装部分
- 画像削除機能
- 画像の更新に失敗した時の対応（フラッシュメッセージ）
＊現時点では画像以外のファイルを登録した際も「プロフィール画像が更新されました」の表示が出る。
（画像の更新はされない。）

