### PR TITLE
add:削除機能の実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -66,6 +66,12 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def remove_avatar
+    @user = current_user
+
+    @user.avatar.purge
+    redirect_to profile_path, notice: "画像を削除しました"
+  end
 
   private
 

--- a/app/views/profiles/_edit_avatar.html.erb
+++ b/app/views/profiles/_edit_avatar.html.erb
@@ -13,6 +13,8 @@
       <div class="text-center hover:text-amber-600 mt-4">
         <%= f.submit "更新" %>
       </div>
+       
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,7 +26,7 @@
               <p>名前</p>
               <%= link_to "編集", edit_name_profile_path,
                           data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
-                          class: "bg-amber-200 text-sm px-1" %>
+                          class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
             <div id="name">
               <%= render "shared/username", user: @user %>
@@ -36,7 +36,7 @@
           <div class="my-4 p-2">
             <div class="flex items-center justify-between mb-2">
               <p>メールアドレス</p>
-              <%= link_to "編集", "#", class: "bg-amber-200 text-sm px-1" %>
+              <%= link_to "編集", "#", class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
             <span><%= @user.email %></span>
           </div>
@@ -44,21 +44,30 @@
           <div class="my-4 p-2">
             <div class="flex items-center justify-between mb-2">
               <p>パスワード</p>
-              <%= link_to "編集", "#", class: "bg-amber-200 text-sm px-1" %>
+              <%= link_to "編集", "#", class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
             <span></span>  
           </div>
 
           <div class="my-4 p-2">
-            <div class="flex items-center justify-between mb-2">
+            <div class="flex items-center mb-2 justify-between">
+            <div class="flex items-center">
               <p>プロフィール画像</p>
+              <%= button_to "削除",
+                          remove_avatar_profile_path,
+                          method: :delete,
+                          data: { turbo_confirm: "本当に削除しますか？" },
+                          class: "text-amber-500 hover:text-amber-800 text-sm px-4" %>
+               </div>
+                <div>
               <%= link_to "編集", edit_avatar_profile_path,
                           data: { turbo_stream: true, turbo_action: "update", turbo_target: "body" },
-                          class: "bg-amber-200 text-sm px-1" %>
+                          class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
+            </div>
             </div>
             <div id="avatar-filename">
               <%= render "profiles/avatar_filename", user: @user %>
-            </div>
+            </div>  
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,5 +43,6 @@ Rails.application.routes.draw do
     patch :update_name
     get :edit_avatar
     patch :update_avatar
+    delete :remove_avatar
   end
 end


### PR DESCRIPTION
## 概要
プロフィール画像の削除機能実装

## 実装内容
**Profilesコントローラー**
`remove_avater`アクション追加

**ルーティング**
`delete`アクション

**ビュー**
基本情報欄の「プロフィール画像」の右側に削除ボタンを設置
`/profiles/show.html.erb`にbutton_toを記述

## できるようになったこと
- 「削除」をクリックすると、「本当に削除しますか？」のモーダルを表示
- さらに「削除」をクリックすると、リダイレクトされ、画像とファイル名が消える。