### PR TITLE
password変更機能の実装

### DIFF
--- a/app/controllers/user/account_passwords_controller.rb
+++ b/app/controllers/user/account_passwords_controller.rb
@@ -1,0 +1,22 @@
+class User::AccountPasswordsController < ApplicationController
+  # ログイン時のパスワード変更
+  before_action :authenticate_user!
+
+  def edit
+  end
+
+  def update
+    if current_user.update_with_password(user_params)
+      bypass_sign_in(current_user) # セッションを維持
+      redirect_to profile_path, notice: "パスワードが更新されました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,21 +1,3 @@
-class Users::PasswordsController < ApplicationController
-  before_action :authenticate_user!
-
-  def edit
-  end
-
-  def update
-    if current_user.update_with_password(user_params)
-      bypass_sign_in(current_user) # セッションを維持
-      redirect_to profile_path, notice: "パスワードが更新されました。"
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
-  private
-
-  def user_params
-    params.require(:user).permit(:current_password, :password, :password_confirmation)
-  end
+class Users::PasswordsController < Devise::PasswordsController
+  # 未ログイン時のパスワード再設定
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,21 @@
+class Users::PasswordsController < ApplicationController
+  before_action :authenticate_user!
+
+  def edit
+  end
+
+  def update
+    if current_user.update_with_password(user_params)
+      bypass_sign_in(current_user) # セッションを維持
+      redirect_to profile_path, notice: "パスワードが更新されました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -44,7 +44,7 @@
           <div class="my-4 p-2">
             <div class="flex items-center justify-between mb-2">
               <p>パスワード</p>
-              <%= link_to "編集", edit_user_password_path,
+              <%= link_to "編集", edit_user_account_password_path,
                             class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
             <span>⚫︎⚫︎⚫︎⚫︎⚫︎⚫︎</span>  

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -44,9 +44,10 @@
           <div class="my-4 p-2">
             <div class="flex items-center justify-between mb-2">
               <p>パスワード</p>
-              <%= link_to "編集", "#", class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
+              <%= link_to "編集", edit_user_password_path,
+                            class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
-            <span></span>  
+            <span>⚫︎⚫︎⚫︎⚫︎⚫︎⚫︎</span>  
           </div>
 
           <div class="my-4 p-2">

--- a/app/views/user/account_passwords/edit.html.erb
+++ b/app/views/user/account_passwords/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="w-full max-w-lg mx-10 ">
       <h1 class="text-2xl md:text-3xl text-center my-6 text-gray-600"><%= t(".change_your_password") %></h1> 
       <div class="border p-4 shadow">
-        <%= form_with(model: current_user, url: user_password_path, html: { method: :put }) do |f| %>
+        <%= form_with(model: current_user, url: user_account_password_path, html: { method: :put }) do |f| %>
           <%= render "devise/shared/error_messages", resource: current_user %>
           <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,46 @@
+<div class="container mx-auto px-4">
+  <div class="flex justify-center">
+    <div class="w-full max-w-lg mx-10 ">
+      <h1 class="text-2xl md:text-3xl text-center my-6 text-gray-600"><%= t(".change_your_password") %></h1> 
+      <div class="border p-4 shadow">
+        <%= form_with(model: current_user, url: user_password_path, html: { method: :put }) do |f| %>
+          <%= render "devise/shared/error_messages", resource: current_user %>
+          <%= f.hidden_field :reset_password_token %>
+
+          <!-- 現在のパスワード入力フォーム -->
+          <div class="field text-sm">
+            <%= f.label :password_confirmation, t(".current_password") %><br />
+            <%= f.password_field :current_password, autocomplete: "current-password",
+                class: "rounded-full mt-1 mb-6 w-full px-3 py-2 border border-gray-300 shadow-sm focus:outline-none focus:ring-cyan-500 focus:border-cyan-500"
+            %>
+          </div>
+
+          <!-- 新しいパスワード入力フォーム -->
+          <div class="field text-sm">
+            <%= f.label :password, t(".new_password") %>
+            <% if @minimum_password_length %>
+            <em class="text-sm">(<%= @minimum_password_length %> 文字以上)</em><br />
+            <% end %>
+            <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
+                class: "rounded-full mt-1 mb-6 w-full px-3 py-2 border border-gray-300 shadow-sm focus:outline-none focus:ring-cyan-500 focus:border-cyan-500"
+            %>
+          </div>
+
+          <!-- 確認用パスワード入力フォーム -->
+          <div class="field text-sm">
+            <%= f.label :password_confirmation, t(".confirm_new_password") %><br />
+            <%= f.password_field :password_confirmation, autocomplete: "new-password",
+                class: "rounded-full mt-1 mb-6 w-full px-3 py-2 border border-gray-300 shadow-sm focus:outline-none focus:ring-cyan-500 focus:border-cyan-500"
+            %>
+          </div>
+
+          <div class="actions text-center">
+            <%= f.submit t(".change_my_password"),
+                class: "w-200 border-4 border-amber-300 hover:bg-amber-300 text-gray font-bold py-2 px-4 rounded-md shadow-md transition"
+            %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,8 +25,7 @@ Devise.setup do |config|
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
   config.mailer_sender = "じぶんLOVE<no-reply@jibunlove.com>"
-  # パスワードリセットの有効期限30分
-  config.reset_password_within = 30.minutes
+
   # Configure the class responsible to send e-mails.
   config.mailer = "UserMailer"
   # Configure the parent class responsible to send e-mails.
@@ -225,7 +224,8 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  # パスワードリセットの有効期限30分
+  config.reset_password_within = 30.minutes
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -35,6 +35,14 @@ ja:
     edit_email:
       title: メールアドレス変更
       submit: 変更する
+  users:
+    passwords:
+      edit:
+        change_your_password: パスワード変更
+        current_password: 現在のパスワード
+        new_password: 新しいパスワード
+        confirm_new_password: 確認用新しいパスワード
+        change_my_password: パスワードを変更する
   header:
     login: ログイン
     logout: ログアウト

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -35,8 +35,8 @@ ja:
     edit_email:
       title: メールアドレス変更
       submit: 変更する
-  users:
-    passwords:
+  user:
+    account_passwords:
       edit:
         change_your_password: パスワード変更
         current_password: 現在のパスワード

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,6 @@ Rails.application.routes.draw do
     delete :remove_avatar
   end
   namespace :user do
-    resource :password, only: [ :edit, :update ]
+    resource :account_password, only: [ :edit, :update ], controller: "account_passwords"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     sessions: "users/sessions",
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }, skip: [ :registrations ]
   # カスタムルーティング
   devise_scope :user do
@@ -46,5 +47,8 @@ Rails.application.routes.draw do
     get :edit_avatar
     patch :update_avatar
     delete :remove_avatar
+  end
+  namespace :user do
+    resource :password, only: [ :edit, :update ]
   end
 end


### PR DESCRIPTION
## 概要
- [x] ログイン時のパスワード変更機能の実装
- [x] 未ログイン時のパスワード再設定機能の修正（コントローラー変更）

## 実装内容
- [x] ログイン時のパスワード変更機能の実装

**AccountPasswordsコントローラー作成**
`edit`アクション
`update`アクション

**ルーティング**
カスタムルーティング作成
- edit_user_account_password_path
- user_account_password_path

**ビュー**
`app/views/user/account_passwords/edit.html.erb`作成
＜入力フォーム＞
現在のパスワード
新しいパスワード
確認用パスワード    
 
- [x] 未ログイン時のパスワード再設定機能の修正（コントローラー変更）

**Passwordsコントローラー作成**

**ルーティング**
devise_for :users,にpasswords: "users/passwords"を追加

## できるようになったこと
- プロフィール画面のパスワード「編集」をクリックすると、パスワード変更画面に遷移する
- 入力フォームに正しく入力し「ハスワードを変更する」をクリックするとパスワードが変更されプロフィール画面に遷移する。
- パスワード変更が成功すると次のフラッシュメッセージが表示される。「パスワードが更新されました」
- 入力に不備があった場合は、エラーメッセージが表示される。




