### PR TITLE
change:posts集計メソッド修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,7 @@
 class PostsController < ApplicationController
   def index
-    @posts = current_user.posts.order(created_at: :desc).page(params[:page])
-    # 合計件数
-    @total_posts_count = @posts.count
-    # 連続記録日数
-    recorded_dates = @posts.pluck(:created_at).map(&:to_date).uniq.sort.reverse
-    @consecutive_days = calculate_consecutive_days(recorded_dates)
+    @user = current_user
+    @posts = @user.posts.order(created_at: :desc).page(params[:page])
   end
 
   def show
@@ -17,21 +13,5 @@ class PostsController < ApplicationController
     post = current_user.posts.find(params[:id])
     post.destroy!
     redirect_to posts_path, notice: t("defaults.flash_message.deleted", item: Post.model_name.human), status: :see_other
-  end
-
-  private
-
-  def calculate_consecutive_days(dates)
-    return 0 if dates.empty?
-
-    count = 1
-    (1...dates.length).each do |i|
-      if dates[i] == dates[i - 1] - 1
-        count += 1
-      else
-        break
-      end
-    end
-    count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
     dates.each_cons(2) { |prev, curr| count += 1 if prev == curr + 1 }
     count
   end
-      
+
   private
   # <プロフィール>
   # 保存時に画像サイズをリサイズしてS3へのアップロード容量を制御

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,12 +10,25 @@ class User < ApplicationRecord
   has_many :badges, through: :user_badges
 
   before_save :resize_avatar
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: %i[ line ]
 
+  # posts集計のインスタンスメソッド
+  def total_posts_count # 累計記録数
+    posts.count
+  end
+
+  def consecutive_days # 連続記録日数
+    dates = posts.pluck(:created_at).map(&:to_date).uniq.sort.reverse
+    count = 1
+    dates.each_cons(2) { |prev, curr| count += 1 if prev == curr + 1 }
+    count
+  end
+      
   private
   # <プロフィール>
   # 保存時に画像サイズをリサイズしてS3へのアップロード容量を制御

--- a/app/views/posts/_total.html.erb
+++ b/app/views/posts/_total.html.erb
@@ -1,4 +1,4 @@
 <div class="mt-4 text-gray-700 space-y-2 text-center md:text-right">
-  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">累計ポジティブ数：<%= @total_posts_count %></p>
-  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">連続記録日数：<%= @consecutive_days %> 日</p>
+  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">累計ポジティブ数：<%= @user.total_posts_count %></p>
+  <p class="text-sm lg:text-base border-b border-gray-400 inline-block">連続記録日数：<%= @user.consecutive_days %> 日</p>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -98,10 +98,10 @@
         <h2>ステータス</h2>
         <div class="border-2 text-sm">
           <div class="my-2 p-2">
-            <p class="text-sm lg:text-base">累計ポジティブ数：<%= @total_posts_count %></p>
+            <p class="text-sm lg:text-base">累計ポジティブ数：<%= @user.total_posts_count %></p>
           </div>
           <div class="my-2 p-2">
-            <p class="text-sm lg:text-base">連続記録日数：<%= @consecutive_days %> 日</p>
+            <p class="text-sm lg:text-base">連続記録日数：<%= @user.consecutive_days %> 日</p>
           </div>
           <div class="mt-2 p-2">
             <p class="text-sm lg:text-base">獲得バッジ</p>


### PR DESCRIPTION
## 概要
Postsの集計メソッドを修正
（User モデルにメソッドを切り出し）
## 実装内容
**集計メソッドの記述**
app/models/user.rbに
累計記録数`total_posts_count`と
連続記録日数`consecutive_days`のメソッドを記述

**コントローラー・ビューの修正**
- Postsコントローラーの集計メソッドを削除
- インスタンス変数をビューに表示
@user.total_posts_count
@user.consecutive_days