### PR TITLE
fix:デプロイ時scssエラーの修正

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link active_admin.css


### PR DESCRIPTION
## 概要
デプロイ時のscssエラーの修正

## エラー内容
```
SassC::SyntaxError: Error: Function rgb is missing argument $green.
>>   border-color: rgb(252 211 77 / var(--tw-border-opacity, 1));
```
ActiveAdminのSCSSとTailwindのビルド済みCSSが一緒にSassCに渡っていることが原因

## コンパイル対象の変更
`//= link active_admin.css`
ActiveAdmin 用のスタイルだけを SCSS としてコンパイル対象にする
