### PR TITLE
fix:デプロイ時sassエラー02

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,8 @@ gem "omniauth-rails_csrf_protection"
 # 管理画面
 gem "activeadmin", "~> 3.3"
 gem "cancancan", "~> 3.6", ">= 3.6.1"
-gem "sassc-rails"
+gem "sass-embedded"
+gem "sassc", require: false   # 依存解決用
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,27 @@ GEM
     formtastic_i18n (0.7.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.32.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -418,14 +439,24 @@ GEM
       logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
+    sass-embedded (1.93.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.32.0)
       base64 (~> 0.2)
@@ -462,7 +493,6 @@ GEM
     tailwindcss-ruby (3.4.17-x86_64-darwin)
     tailwindcss-ruby (3.4.17-x86_64-linux)
     thor (1.3.2)
-    tilt (2.6.1)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -528,7 +558,8 @@ DEPENDENCIES
   redis (~> 4.8)
   rubocop-rails-omakase
   ruby-openai (~> 8.1)
-  sassc-rails
+  sass-embedded
+  sassc
   selenium-webdriver
   sidekiq (~> 7.2)
   sprockets-rails


### PR DESCRIPTION
## 概要
デプロイ時sassエラー02
（sass-embedded への移行）
## エラー内容
前回と同様
```
SassC::SyntaxError: Error: Function rgb is missing argument $green. (SassC::SyntaxError)
        on line 1194 of stdin
>>   border-color: rgb(252 211 77 / var(--tw-border-opacity, 1));
```
## sass-embedded への移行
前回のコンパイル対象の修正では解決できなかったため、
gem "sassc-rails"=>gem "sass-embedded"へ変更
