### PR TITLE
add:LINE友だち追加機能

### DIFF
--- a/app/controllers/line_controller.rb
+++ b/app/controllers/line_controller.rb
@@ -1,0 +1,35 @@
+class LineController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def webhook
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_secret = Rails.application.credentials.dig(:line, :channel_secret)
+      config.channel_token  = Rails.application.credentials.dig(:line, :channel_token)
+    end
+
+    unless client.validate_signature(body, signature)
+      return head :bad_request
+    end
+
+    events = client.parse_events_from(body)
+
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Follow
+        line_user_id = event['source']['userId']
+
+        # 誰のline_user_idか判定
+        # LINE連携を待機している特定のユーザーをデータベースから探す
+        user = User.find_by(waiting_for_line_link: true)
+        if user
+          user.update!(line_user_id: line_user_id, waiting_for_line_link: false)
+        end
+      end
+    end
+
+    head :ok
+  end
+end

--- a/app/controllers/line_controller.rb
+++ b/app/controllers/line_controller.rb
@@ -3,7 +3,7 @@ class LineController < ApplicationController
 
   def webhook
     body = request.body.read
-    signature = request.env['HTTP_X_LINE_SIGNATURE']
+    signature = request.env["HTTP_X_LINE_SIGNATURE"]
 
     client = Line::Bot::Client.new do |config|
       config.channel_secret = Rails.application.credentials.dig(:line, :channel_secret)
@@ -19,7 +19,7 @@ class LineController < ApplicationController
     events.each do |event|
       case event
       when Line::Bot::Event::Follow
-        line_user_id = event['source']['userId']
+        line_user_id = event["source"]["userId"]
 
         # 誰のline_user_idか判定
         # LINE連携を待機している特定のユーザーをデータベースから探す

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -99,6 +99,13 @@
                           class: "bg-amber-200 hover:bg-amber-500 text-sm px-1" %>
             </div>
           </div>
+          <div class="my-4 p-2">
+            <div class="flex items-center justify-between mb-2">
+            <p>LINE連携</p>
+            <%= link_to "https://lin.ee/VsVCHh4" do %>
+              <%= image_tag "https://scdn.line-apps.com/n/line_add_friends/btn/ja.png", alt: "友だち追加", class: "h-6" %>
+            <% end %>
+          </div>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
   get "how_to_write", to: "descriptions#how_to_write", as: :how_to_write
   get "how_to_use", to: "descriptions#how_to_use", as: :how_to_use
   get "profile_setting", to: "descriptions#profile_setting", as: :profile_setting
+  # line友達登録
+  post "line/webhook", to: "line#webhook"
 
   resources :chats, only: [ :index, :create ]
   resources :posts, only: [ :index, :show, :destroy ] do


### PR DESCRIPTION
## 概要
LINEの友達追加機能の実装
## 実装内容
**ルーティング**
post "line/webhook"を追加

**followイベントを受け取るコントローラー作成**
フラグ方式でRailsのユーザーとLINEのuserIdを紐付け
＊同時に複数人が押すとズレる可能性あるため、のちにURLパラメータ方式に変更予定

**友だち追加ボタンの設置**
プロフィール画面の「各種設定状況」欄にボタン設置

## できるようになったこと
- プロフィール画面の「友だち追加」ボタンをクリックすると、LINE友だち追加画面へ遷移する。

## 今後実装すること
- 友だち追加が完了するとLINE連携「連携済み」の表示を出す。
- LINEのuserIdを紐付けをURLパラメータ方式に変更